### PR TITLE
fix: add edge runtime + cache headers to OG image route

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,5 +1,9 @@
 import { ImageResponse } from "next/og";
 
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 const size = {
   width: 600,
   height: 400,
@@ -678,6 +682,11 @@ export async function GET() {
         </div>
       </div>
     ),
-    { ...size }
+    {
+      ...size,
+      headers: {
+        "Cache-Control": "public, max-age=120, s-maxage=120, stale-while-revalidate=60",
+      },
+    }
   );
 }


### PR DESCRIPTION
- Add runtime='edge' for faster response times
- Add dynamic='force-dynamic' to prevent static caching
- Set Cache-Control max-age=120s so Farcaster unfurler refreshes
- Ensures live match data is always fresh in OG card previews